### PR TITLE
Update to clojure 1.9.0, fixes specs, add s/keys coercion

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nl.zeekat/spec-coerce "1.0.0-alpha6-SNAPSHOT"
+(defproject spec-coerce "1.0.0-alpha6-SNAPSHOT"
   :description "Coerce from specs"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject spec-coerce "1.0.0-alpha6-SNAPSHOT"
+(defproject nl.zeekat/spec-coerce "1.0.0-alpha6-SNAPSHOT"
   :description "Coerce from specs"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                                        :optimizations :none}}]}
 
   :profiles {:dev  {:dependencies [[org.clojure/test.check "0.9.0"]
-                                   [org.clojure/clojure "1.9.0-alpha17"]
+                                   [org.clojure/clojure "1.9.0"]
                                    [org.clojure/clojurescript "1.9.671"]]}
 
-             :test {:dependencies [[org.clojure/clojure "1.9.0-alpha17"]]}})
+             :test {:dependencies [[org.clojure/clojure "1.9.0"]]}})

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -117,7 +117,7 @@
       x)))
 
 #?(:clj
-   (defn parse-bigdec [x]
+   (defn parse-decimal [x]
      (if (string? x)
        (if (str/ends-with? x "M")
          (bigdec (subs x 0 (dec (count x))))
@@ -167,7 +167,7 @@
 (defmethod sym->coercer `s/map-of [form] (parse-map-of form))
 
 #?(:clj (defmethod sym->coercer `uri? [_] parse-uri))
-#?(:clj (defmethod sym->coercer `bigdec? [_] parse-bigdec))
+#?(:clj (defmethod sym->coercer `decimal? [_] parse-decimal))
 
 (defmethod sym->coercer :default [_] identity)
 

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -148,3 +148,21 @@
           ::not-defined   :bla
           :unqualified    12
           :sub            {::infer-int 42}})))
+
+(s/def ::bool boolean?)
+(s/def ::simple-keys (s/keys :req [::infer-int]
+                             :opt [::bool]))
+(s/def ::nested-keys (s/keys :req [::infer-form ::simple-keys]
+                             :req-un [::bool]))
+
+(deftest test-coerce-keys
+  (is (= {::infer-int 123}
+         (sc/coerce ::simple-keys {::infer-int "123"})))
+  (is (= {::infer-form [1 2 3]
+          ::simple-keys   {::infer-int 456
+                           ::bool      true}
+          :bool true}
+         (sc/coerce ::nested-keys {::infer-form  ["1" "2" "3"]
+                                   ::simple-keys {::infer-int "456"
+                                                  ::bool      "true"}
+                                   :bool         "true"}))))

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -7,12 +7,15 @@
             [clojure.test.check :as tc]
             [clojure.test.check.generators]
             [clojure.test.check.properties :as prop]
+            [clojure.spec.test.alpha :as st]
     #?(:clj
             [clojure.test.check.clojure-test :refer [defspec]])
     #?(:cljs [clojure.test.check.clojure-test :refer-macros [defspec]])
             [spec-coerce.core :as sc])
   #?(:clj
      (:import (java.net URI))))
+
+#?(:clj (st/instrument))
 
 (s/def ::infer-int int?)
 (s/def ::infer-and-spec (s/and int? #(> % 10)))

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -19,7 +19,7 @@
 (s/def ::infer-and-spec-indirect (s/and ::infer-int #(> % 10)))
 (s/def ::infer-form (s/coll-of int?))
 
-#?(:clj (s/def ::infer-bigdec? bigdec?))
+#?(:clj (s/def ::infer-decimal? decimal?))
 
 (sc/def ::some-coercion sc/parse-long)
 
@@ -80,8 +80,8 @@
     `(s/or :int int? :double double? :bool boolean?) "true" true
 
     #?@(:clj [`uri? "http://site.com" (URI. "http://site.com")])
-    #?@(:clj [`bigdec? "42.42" 42.42M
-              `bigdec? "42.42M" 42.42M])))
+    #?@(:clj [`decimal? "42.42" 42.42M
+              `decimal? "42.42M" 42.42M])))
 
 (def test-gens
   {`inst? (s/gen (s/inst-in #inst "1980" #inst "9999"))})
@@ -126,7 +126,7 @@
     ::second-layer "41" 42
     ::second-layer-and "41" 42
 
-    #?@(:clj [::infer-bigdec? "123.4" 123.4M])))
+    #?@(:clj [::infer-decimal? "123.4" 123.4M])))
 
 (deftest test-coerce-structure
   (is (= (sc/coerce-structure {::some-coercion "321"


### PR DESCRIPTION
Hi, I was playing around with your awesome work and I was missing an s/keys coercion, so I added that. I also ran into lots of errors running the tests with spec instrumentation on, so I removed a whole bunch of specs that seemed to be erroneously strict, so now the tests run with instrumentation on.