### PR TITLE
Address #10 by adding more date/time formats for inst? coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.0.0-??? in progress]
+- `inst?` coercion now accepts a wider range of date & date/time patterns
+- `spec-coerce.core/*inst-format*` is dynamic and can be rebound if you need more formats
+
 ## [1.0.0-alpha6]
 - Support `s/keys`
 - More tolerant specs for internals
@@ -17,9 +21,9 @@
 
 ## [1.0.0-alpha3]
 
-- Support `s/coll-of` predicate. 
-- Support `s/map-of` predicate. 
-- Support `s/or` predicate. 
+- Support `s/coll-of` predicate.
+- Support `s/map-of` predicate.
+- Support `s/or` predicate.
 
 ## [1.0.0-alpha2]
 

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,8 @@
   :source-paths ["src"]
   :test-paths ["test"]
 
+  :jvm-opts ["-Duser.timezone=GMT"]
+
   :cljsbuild {:builds [{:id           "test-build"
                         :source-paths ["src" "test"]
                         :compiler     {:output-to     "out/testable.js"
@@ -20,6 +22,6 @@
 
   :profiles {:dev  {:dependencies [[org.clojure/test.check "0.9.0"]
                                    [org.clojure/clojure "1.9.0"]
-                                   [org.clojure/clojurescript "1.9.671"]]}
+                                   [org.clojure/clojurescript "1.9.946"]]}
 
              :test {:dependencies [[org.clojure/clojure "1.9.0"]]}})

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -70,10 +70,18 @@
        (catch Exception _
          (let [zone (ZoneId/of (.getID (TimeZone/getDefault)))]
            (or (some #(try
-                        (Date/from (.toInstant (.atZone (LocalDateTime/parse x (DateTimeFormatter/ofPattern %)) zone)))
+                        (Date/from
+                         (.toInstant
+                          (.atZone
+                           (LocalDateTime/parse x (DateTimeFormatter/ofPattern %))
+                           zone)))
                         (catch Exception _)) *inst-formats*)
                (some #(try
-                        (Date/from (.toInstant (.atStartOfDay (LocalDate/parse x (DateTimeFormatter/ofPattern %)) zone)))
+                        (Date/from
+                         (.toInstant
+                          (.atStartOfDay
+                           (LocalDate/parse x (DateTimeFormatter/ofPattern %))
+                           zone)))
                         (catch Exception _)) *inst-formats*)
                x))))))
 
@@ -83,7 +91,6 @@
       #?(:clj  (flexible-parse-inst x)
          :cljs (js/Date. x))
       (catch #?(:clj Exception :cljs :default) _
-        (println "what?" (.getMessage _))
         x))
     x))
 

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -7,8 +7,10 @@
     #?(:clj
             [clojure.instant]))
   #?(:clj
-     (:import (java.util UUID)
-              (java.net URI))))
+     (:import (java.util Date TimeZone UUID)
+              (java.net URI)
+              (java.time LocalDate LocalDateTime ZoneId)
+              (java.time.format DateTimeFormatter))))
 
 (declare coerce)
 
@@ -54,12 +56,34 @@
         x))
     x))
 
+#?(:clj (def ^:dynamic *inst-formats*
+          ["yyyy/M/d H:m:s" "yyyy/M/d H:m" "yyyy/M/d"
+           "M/d/yyyy H:m:s" "M/d/yyyy H:m" "M/d/yyyy"
+           "yyyy-M-d H:m:s" "yyyy-M-d H:m" "yyyy-M-d"
+           "M-d-yyyy H:m:s" "M-d-yyyy H:m" "M-d-yyyy"
+           "EEE MMM dd HH:mm:ss zzz yyyy"]))
+
+#?(:clj
+   (defn- flexible-parse-inst [x]
+     (try
+       (clojure.instant/read-instant-timestamp x)
+       (catch Exception _
+         (let [zone (ZoneId/of (.getID (TimeZone/getDefault)))]
+           (or (some #(try
+                        (Date/from (.toInstant (.atZone (LocalDateTime/parse x (DateTimeFormatter/ofPattern %)) zone)))
+                        (catch Exception _)) *inst-formats*)
+               (some #(try
+                        (Date/from (.toInstant (.atStartOfDay (LocalDate/parse x (DateTimeFormatter/ofPattern %)) zone)))
+                        (catch Exception _)) *inst-formats*)
+               x))))))
+
 (defn parse-inst [x]
   (if (string? x)
     (try
-      #?(:clj  (clojure.instant/read-instant-timestamp x)
+      #?(:clj  (flexible-parse-inst x)
          :cljs (js/Date. x))
       (catch #?(:clj Exception :cljs :default) _
+        (println "what?" (.getMessage _))
         x))
     x))
 

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -121,14 +121,16 @@
                          :result res}))))))
 
 #?(:clj (deftest test-coerce-inst
-          (are [input output] (= (.getTime (sc/coerce `inst? input)) (.getTime output))
+          ;; use .getTime to avoid java.sql.Timestamp/java.util.Date differences
+          ;; we don't check s/valid? here, just that the date/time roundtrips
+          (are [input output] (= (.getTime (sc/coerce `inst? input))
+                                 (.getTime output))
             "9/28/2018 22:06" #inst "2018-09-28T22:06"
-            (str "Fri Sep 28 22:06:52 " (.getID (java.util.TimeZone/getDefault)) " 2018") #inst "2018-09-28T22:06:52"
-            "2018-09-28" #inst "2018-09-28")))
-   :cljs (deftest test-coerce-inst
-          (are [input output] (= (sc/coerce `inst? input) output)
-            "9/28/2018 22:06" #inst "2018-09-28T22:06"
-            "2018-09-28" #inst "2018-09-28")))
+            (str "Fri Sep 28 22:06:52 "
+                 (.getID (java.util.TimeZone/getDefault))
+                 " 2018")     #inst "2018-09-28T22:06:52"
+            "2018-09-28"      #inst "2018-09-28"
+            "9/28/2018"       #inst "2018-09-28")))
 
 (deftest test-coerce-inference-test
   (are [keyword input output] (= (sc/coerce keyword input) output)

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -120,6 +120,16 @@
                         {:symbol s
                          :result res}))))))
 
+#?(:clj (deftest test-coerce-inst
+          (are [input output] (= (.getTime (sc/coerce `inst? input)) (.getTime output))
+            "9/28/2018 22:06" #inst "2018-09-28T22:06"
+            (str "Fri Sep 28 22:06:52 " (.getID (java.util.TimeZone/getDefault)) " 2018") #inst "2018-09-28T22:06:52"
+            "2018-09-28" #inst "2018-09-28")))
+   :cljs (deftest test-coerce-inst
+          (are [input output] (= (sc/coerce `inst? input) output)
+            "9/28/2018 22:06" #inst "2018-09-28T22:06"
+            "2018-09-28" #inst "2018-09-28")))
+
 (deftest test-coerce-inference-test
   (are [keyword input output] (= (sc/coerce keyword input) output)
     ::infer-int "123" 123


### PR DESCRIPTION
`spec-coerce.core/*inst-formats*` can be rebound to a different set of input formats. Anything that `clojure.instant/read-instant-timestamp` can accept is always valid (as before).

I tried to add some `inst?` coercion tests for CLJS as well but wasn't very successful in getting `#inst` values to compare equal. Note that I set the JVM to GMT to avoid timezone issues going through `LocalDate/Time` and trying to compare against `#inst`.