### PR TITLE
Allow overriding of coercers in the registry in a local context

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Learn by example:
 
 ; Custom registered keywords always takes precedence over inference
 (sc/coerce ::my-custom-attr "Z") ; => #user.SomeClass{:x "Z"}
+
+; Coercers in the registry can be overriden within a specific context
+(binding [sc/*overrides* {::my-custom-attr keyword}]
+  (sc/coerce ::my-custom-attr "Z")) ; => :Z
 ```
 
 Examples from predicate to coerced value:

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -16,6 +16,14 @@
 
 (defonce ^:private registry-ref (atom {}))
 
+(def ^:dynamic *overrides*
+  "Allows overriding of specs in the registry within a local binding
+  context.
+
+  (binding [sc/*overrides* {::my-key my-coerce-fn}]
+    (sc/coerce ::my/spec data))"
+  {})
+
 (defn parse-long [x]
   (if (string? x)
     (try
@@ -243,7 +251,7 @@
   "Get the coercing function from a given key. First it tries to lookup the coercion
   on the registry, otherwise try to infer from the specs. In case nothing is found, identity function is returned."
   (or (when (qualified-keyword? k)
-        (si/registry-lookup @registry-ref k))
+        (si/registry-lookup (merge @registry-ref *overrides*) k))
       (infer-coercion k)))
 
 (defn coerce [k x]

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -200,3 +200,25 @@
                                    ::simple-keys {::infer-int "456"
                                                   ::bool      "true"}
                                    :bool         "true"}))))
+
+(s/def ::head double?)
+(s/def ::body int?)
+(s/def ::arm  int?)
+(s/def ::leg  double?)
+(s/def ::arms (s/coll-of ::arm))
+(s/def ::legs (s/coll-of ::leg))
+(s/def ::name string?)
+(s/def ::animal (s/keys :req    [::head ::body ::arms ::legs]
+                        :opt-un [::name ::id]))
+
+(deftest test-coerce-with-registry-overrides
+  (testing "it uses overrides when provided"
+    (is (= {::head 1 ::body 16 ::arms [4 4] ::legs [7 7] :name :john}
+           (binding [sc/*overrides* {::head (sc/sym->coercer `int?)
+                                     ::leg  (sc/sym->coercer `int?)
+                                     ::name (sc/sym->coercer `keyword?)}]
+             (sc/coerce ::animal {::head "1"
+                                  ::body "16"
+                                  ::arms ["4" "4"]
+                                  ::legs ["7" "7"]
+                                  :name "john"}))))))


### PR DESCRIPTION
Sometimes transformation away from the spec'ed format into a similar,
but slightly different format is useful. For example when dealing with
native datatypes that a storage engine doesn't understand. In these
circumstances it's useful to be able to leverage the spec structure,
but apply a different transformation for a set of keys, wherever those keys
are encountered.

By adding the dynamic var *overrides* we are able to rebind the
coercer for any key in a limited scope, allowing us to perform custom
transformations without having to specify where that key appears.
This is in contrast to the `coerce-structure` override functionality in that
it allows coercers to be overridden by qualified key, with the new
transformation being used anywhere that key appears.