### PR TITLE
Handle number->number, any->string, and symbol->keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .hg/
 *.iml
 .DS_Store
+.cpcache/

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -111,11 +111,12 @@
     x))
 
 (defn parse-keyword [x]
-  (if (string? x)
-    (if (str/starts-with? x ":")
-      (keyword (subs x 1))
-      (keyword x))
-    x))
+  (cond (string? x)
+        (if (str/starts-with? x ":")
+          (keyword (subs x 1))
+          (keyword x))
+        (symbol? x) (keyword x)
+        :else       x))
 
 (defn parse-symbol [x]
   (if (string? x)

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -25,35 +25,37 @@
   {})
 
 (defn parse-long [x]
-  (if (string? x)
-    (try
-      #?(:clj  (Long/parseLong x)
-         :cljs (if (= "NaN" x)
-                 js/NaN
-                 (let [v (js/parseInt x)]
-                   (if (js/isNaN v) x v))))
-      (catch #?(:clj Exception :cljs :default) _
-        x))
-    x))
+  (cond  (string? x)
+         (try
+           #?(:clj  (Long/parseLong x)
+              :cljs (if (= "NaN" x)
+                      js/NaN
+                      (let [v (js/parseInt x)]
+                        (if (js/isNaN v) x v))))
+           (catch #?(:clj Exception :cljs :default) _
+             x))
+         (number? x) (long x)
+         :else       x))
 
 (defn parse-double [x]
-  (if (string? x)
-    (try
-      #?(:clj  (case x
-                 "##-Inf" ##-Inf
-                 "##Inf" ##Inf
-                 "##NaN" ##NaN
-                 "NaN" ##NaN
-                 "Infinity" ##Inf
-                 "-Infinity" ##-Inf
-                 (Double/parseDouble x))
-         :cljs (if (= "NaN" x)
-                 js/NaN
-                 (let [v (js/parseFloat x)]
-                   (if (js/isNaN v) x v))))
-      (catch #?(:clj Exception :cljs :default) _
-        x))
-    x))
+  (cond (string? x)
+        (try
+          #?(:clj  (case x
+                     "##-Inf"    ##-Inf
+                     "##Inf"     ##Inf
+                     "##NaN"     ##NaN
+                     "NaN"       ##NaN
+                     "Infinity"  ##Inf
+                     "-Infinity" ##-Inf
+                     (Double/parseDouble x))
+             :cljs (if (= "NaN" x)
+                     js/NaN
+                     (let [v (js/parseFloat x)]
+                       (if (js/isNaN v) x v))))
+          (catch #?(:clj Exception :cljs :default) _
+            x))
+        (number? x) (double x)
+        :else       x))
 
 (defn parse-uuid [x]
   (if (string? x)

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -187,6 +187,7 @@
       (first x)
       x)))
 
+(defmethod sym->coercer `string? [_] str)
 (defmethod sym->coercer `number? [_] parse-double)
 (defmethod sym->coercer `integer? [_] parse-long)
 (defmethod sym->coercer `int? [_] parse-long)

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -65,6 +65,8 @@
     `number? "foo" "foo"
     `integer? "42" 42
     `int? "42" 42
+    `int? 42.0 42
+    `int? 42.5 42
     `pos-int? "42" 42
     `neg-int? "-42" -42
     `nat-int? "10" 10
@@ -72,6 +74,11 @@
     `odd? "9" 9
     `float? "42.42" 42.42
     `double? "42.42" 42.42
+    `double? 42.42 42.42
+    `double? 42 42.0
+    `string? 42 "42"
+    `string? :a ":a"
+    `string? :foo/bar ":foo/bar"
     `boolean? "true" true
     `boolean? "false" false
     `ident? ":foo/bar" :foo/bar
@@ -80,6 +87,7 @@
     `qualified-ident? ":foo/baz" :foo/baz
     `keyword? "keyword" :keyword
     `keyword? ":keyword" :keyword
+    `keyword? 'symbol :symbol
     `simple-keyword? ":simple-keyword" :simple-keyword
     `qualified-keyword? ":qualified/keyword" :qualified/keyword
     `symbol? "sym" 'sym


### PR DESCRIPTION
I'm attempting to use spec-coerce as the backend for cyrus-config: https://github.com/dryewo/cyrus-config/pull/2

During the process, I found a few conversions that I expected to work but didn't, namely:

`int?` -> `double?` (remains an `int`, and thus fails `coerce!`)
`any?` -> `string?` (no `string?` handler existed yet)
`symbol?` -> `keyword?` (can be done by simply calling `keyword` on it.)

Resolves #25 and then some