### PR TITLE
Infer coercion from specs given as sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Learn by example:
 (sc/coerce ::nilable "nil") ; => nil
 (sc/coerce ::nilable "foo") ; => "foo"
 
+; The coercion can even be automatically inferred from specs given explicitly as sets of a homogeneous type
+(s/def ::enum #{:a :b :c})
+(sc/coerce ::enum ":a") ; => :a
+
 ; If you wanna play around or use a specific coercion, you can pass the predicate symbol directly
 (sc/coerce `int? "40") ; => 40
 

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -185,15 +185,15 @@
 (defn type->sym [x]
   (cond (int? x)     `integer?
         (float? x)   `float?
-        (boolean? x) `boolean?
-        (ident? x)   `ident?
+        (boolean? x) `boolean?   ;; pointless but valid
+        ;;(symbol? x)  `symbol?  ;; doesn't work.
+        ;;(ident? x)   `ident?   ;; doesn't work.
         (string? x)  `string?
         (keyword? x) `keyword?
         (uuid? x)    `uuid?
-        (nil? x)     `nil?
-        (symbol? x)  `symbol?
+        (nil? x)     `nil?       ;; even more pointless but stil valid
 
-        #?(:clj (uri? x))     #?(:clj `uri?)
+        ;;#?(:clj (uri? x))     #?(:clj `uri?) ;; doesn't work.
         #?(:clj (decimal? x)) #?(:clj `decimal?)))
 
 (defmulti sym->coercer

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -182,11 +182,25 @@
        (URI. x)
        x)))
 
+(defn type->sym [x]
+  (cond (int? x)     `integer?
+        (float? x)   `float?
+        (boolean? x) `boolean?
+        (ident? x)   `ident?
+        (string? x)  `string?
+        (keyword? x) `keyword?
+        (uuid? x)    `uuid?
+        (nil? x)     `nil?
+        (symbol? x)  `symbol?
+
+        #?(:clj (uri? x))     #?(:clj `uri?)
+        #?(:clj (decimal? x)) #?(:clj `decimal?)))
+
 (defmulti sym->coercer
   (fn [x]
-    (if (sequential? x)
-      (first x)
-      x)))
+    (cond (set? x)        (type->sym (first x))
+          (sequential? x) (first x)
+          :else           x)))
 
 (defmethod sym->coercer `string? [_] str)
 (defmethod sym->coercer `number? [_] parse-double)

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -199,16 +199,14 @@
 (defn spec-is-set? [x]
   "If the spec is given as a set, and every member of the set is the same type,
   then we can infer a coercion from that shared type."
-  (let [infer-spec (try (eval x)
-                        (catch Exception e x))]
-    (and (set? infer-spec)
-         (->> infer-spec
-              (map type)
-              (apply =)))))
+  (and (set? x)
+       (->> x
+            (map type)
+            (apply =))))
 
 (defmulti sym->coercer
   (fn [x]
-    (cond (spec-is-set? x) (-> x eval first type->sym)
+    (cond (spec-is-set? x) (-> x first type->sym)
           (sequential? x)  (first x)
           :else            x)))
 

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -196,7 +196,7 @@
         ;;#?(:clj (uri? x))     #?(:clj `uri?) ;; doesn't work.
         #?(:clj (decimal? x)) #?(:clj `decimal?)))
 
-(defn spec-is-set? [x]
+(defn spec-is-homogeneous-set? [x]
   "If the spec is given as a set, and every member of the set is the same type,
   then we can infer a coercion from that shared type."
   (and (set? x)
@@ -206,7 +206,7 @@
 
 (defmulti sym->coercer
   (fn [x]
-    (cond (spec-is-set? x) (-> x first type->sym)
+    (cond (spec-is-homogeneous-set? x) (-> x first type->sym)
           (sequential? x)  (first x)
           :else            x)))
 

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -38,6 +38,20 @@
 (s/def ::nilable-int (s/nilable ::infer-int))
 (s/def ::nilable-pos-int (s/nilable (s/and ::infer-int pos?)))
 
+(s/def ::int-set #{1 2})
+(s/def ::float-set #{1.2 2.1})
+(s/def ::boolean-set #{true})
+(s/def ::symbol-set #{'foo/bar 'bar/foo})
+(s/def ::ident-set #{'foo/bar :bar/foo})
+(s/def ::string-set #{"hey" "there"})
+(s/def ::keyword-set #{:a :b})
+(s/def ::uuid-set #{#uuid "d6e73cc5-95bc-496a-951c-87f11af0d839"
+                    #uuid "a6e73cc5-95bc-496a-951c-87f11af0d839"})
+(s/def ::nil-set #{nil})
+#?(:clj (s/def ::uri-set #{(URI. "http://site.com")
+                           (URI. "http://site.org")}))
+#?(:clj (s/def ::decimal-set #{42.42M 1.1M}))
+
 (deftest test-coerce-from-registry
   (testing "it uses the registry to coerce a key"
     (is (= (sc/coerce ::some-coercion "123") 123)))
@@ -49,7 +63,19 @@
     (is (= (sc/coerce ::infer-nilable "123") 123))
     (is (= (sc/coerce ::infer-nilable "nil") nil))
     (is (= (sc/coerce ::nilable-int "10") 10))
-    (is (= (sc/coerce ::nilable-pos-int "10") 10))))
+    (is (= (sc/coerce ::nilable-pos-int "10") 10)))
+
+  (testing "specs given as sets"
+    (is (= (sc/coerce ::int-set "1") 1))
+    (is (= (sc/coerce ::float-set "1.2") 1.2))
+    (is (= (sc/coerce ::boolean-set "true") true))
+    ;;(is (= (sc/coerce ::symbol-set "foo/bar") 'foo/bar))
+    (is (= (sc/coerce ::string-set "hey") "hey"))
+    (is (= (sc/coerce ::keyword-set ":b") :b))
+    (is (= (sc/coerce ::uuid-set "d6e73cc5-95bc-496a-951c-87f11af0d839") #uuid "d6e73cc5-95bc-496a-951c-87f11af0d839"))
+    (is (= (sc/coerce ::nil-set "nil") nil))
+    ;;#?(:clj (is (= (sc/coerce ::uri-set "http://site.com") (URI. "http://site.com"))))
+    #?(:clj (is (= (sc/coerce ::decimal-set "42.42M") 42.42M)))))
 
 (deftest test-coerce!
   (is (= (sc/coerce! ::infer-int "123") 123))

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -92,12 +92,15 @@
     (is (= (sc/coerce ::nil-set "nil") nil))
     ;;#?(:clj (is (= (sc/coerce ::uri-set "http://site.com") (URI. "http://site.com"))))
     #?(:clj (is (= (sc/coerce ::decimal-set "42.42M") 42.42M)))
-    (is (= (sc/coerce ::referenced-set ":a") :a))
-    (is (= (sc/coerce ::calculated-set ":foo") :foo))
-    (is (= (sc/coerce ::nilable-referenced-set ":a") :a))
-    (is (= (sc/coerce ::nilable-calculated-set ":foo") :foo))
-    (is (= (sc/coerce ::nilable-referenced-set-kw ":a") :a))
-    (is (= (sc/coerce ::nilable-calculated-set-kw ":foo") :foo))
+
+    ;; The following tests can't work without using `eval`. We will avoid this
+    ;; and hope that spec2 will give us a better way.
+    ;;(is (= (sc/coerce ::referenced-set ":a") :a))
+    ;;(is (= (sc/coerce ::calculated-set ":foo") :foo))
+    ;;(is (= (sc/coerce ::nilable-referenced-set ":a") :a))
+    ;;(is (= (sc/coerce ::nilable-calculated-set ":foo") :foo))
+    ;;(is (= (sc/coerce ::nilable-referenced-set-kw ":a") :a))
+    ;;(is (= (sc/coerce ::nilable-calculated-set-kw ":foo") :foo))
 
     (is (= (sc/coerce ::unevaluatable-spec "just a string") "just a string"))))
 

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -65,6 +65,9 @@
 (s/def ::nilable-referenced-set-kw (s/nilable ::referenced-set))
 (s/def ::nilable-calculated-set-kw (s/nilable ::calculated-set))
 
+(s/def ::unevaluatable-spec (letfn [(pred [x] (string? x))]
+                              (s/spec pred)))
+
 (deftest test-coerce-from-registry
   (testing "it uses the registry to coerce a key"
     (is (= (sc/coerce ::some-coercion "123") 123)))
@@ -94,7 +97,9 @@
     (is (= (sc/coerce ::nilable-referenced-set ":a") :a))
     (is (= (sc/coerce ::nilable-calculated-set ":foo") :foo))
     (is (= (sc/coerce ::nilable-referenced-set-kw ":a") :a))
-    (is (= (sc/coerce ::nilable-calculated-set-kw ":foo") :foo))))
+    (is (= (sc/coerce ::nilable-calculated-set-kw ":foo") :foo))
+
+    (is (= (sc/coerce ::unevaluatable-spec "just a string") "just a string"))))
 
 (deftest test-coerce!
   (is (= (sc/coerce! ::infer-int "123") 123))

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -52,6 +52,19 @@
                            (URI. "http://site.org")}))
 #?(:clj (s/def ::decimal-set #{42.42M 1.1M}))
 
+(def enum-set #{:a :b})
+(s/def ::referenced-set enum-set)
+
+(def enum-map {:foo "bar"
+               :baz "qux"})
+(s/def ::calculated-set (->> enum-map keys (into #{})))
+
+(s/def ::nilable-referenced-set (s/nilable enum-set))
+(s/def ::nilable-calculated-set (s/nilable (->> enum-map keys (into #{}))))
+
+(s/def ::nilable-referenced-set-kw (s/nilable ::referenced-set))
+(s/def ::nilable-calculated-set-kw (s/nilable ::calculated-set))
+
 (deftest test-coerce-from-registry
   (testing "it uses the registry to coerce a key"
     (is (= (sc/coerce ::some-coercion "123") 123)))
@@ -75,7 +88,13 @@
     (is (= (sc/coerce ::uuid-set "d6e73cc5-95bc-496a-951c-87f11af0d839") #uuid "d6e73cc5-95bc-496a-951c-87f11af0d839"))
     (is (= (sc/coerce ::nil-set "nil") nil))
     ;;#?(:clj (is (= (sc/coerce ::uri-set "http://site.com") (URI. "http://site.com"))))
-    #?(:clj (is (= (sc/coerce ::decimal-set "42.42M") 42.42M)))))
+    #?(:clj (is (= (sc/coerce ::decimal-set "42.42M") 42.42M)))
+    (is (= (sc/coerce ::referenced-set ":a") :a))
+    (is (= (sc/coerce ::calculated-set ":foo") :foo))
+    (is (= (sc/coerce ::nilable-referenced-set ":a") :a))
+    (is (= (sc/coerce ::nilable-calculated-set ":foo") :foo))
+    (is (= (sc/coerce ::nilable-referenced-set-kw ":a") :a))
+    (is (= (sc/coerce ::nilable-calculated-set-kw ":foo") :foo))))
 
 (deftest test-coerce!
   (is (= (sc/coerce! ::infer-int "123") 123))


### PR DESCRIPTION
It's common for specs to be given as sets, especially as sets of keywords. This is your classic "enumeration" case, like the below:
```clj
(s/def ::color #{:red :orange :yellow :green :blue :etc})
```
If all of the elements of the set are the same type, then we can infer what coercion to use, thus saving some typing. In the above case, it would be the same coercion we would use with `keyword?`, and effectively would replace the need for the following line:
```clj
(sc/def ::color keyword?)
```

This PR adds this ability, for most (unfortunately not all) of the same types of coercions spec-coerce already supports.