### PR TITLE
Add s/merge support

### DIFF
--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -266,19 +266,21 @@
 (defn parse-merge
   [[_ & pred-forms]]
   (fn [x]
-    (reduce (fn [m pred-form]
-              ;; for every pred-form coerce to new value;
-              ;; we need to compare key by key what changed so that
-              ;; defaults do not overwrite coerced values
-              (into m
-                    (keep (fn [[k v]]
-                            (let [new-val (coerce k v)]
-                              ;; new-val doesn't match default, keep it
-                              (when-not (= (get x k) new-val)
-                                [k new-val]))))
-                    (coerce pred-form x)))
-            x
-            pred-forms)))
+    (if (associative? x)
+      (reduce (fn [m pred-form]
+                ;; for every pred-form coerce to new value;
+                ;; we need to compare key by key what changed so that
+                ;; defaults do not overwrite coerced values
+                (into m
+                      (keep (fn [[k v]]
+                              (let [new-val (coerce k v)]
+                                ;; new-val doesn't match default, keep it
+                                (when-not (= (get x k) new-val)
+                                  [k new-val]))))
+                      (coerce pred-form x)))
+              x
+              pred-forms)
+      x)))
 
 (defmethod sym->coercer `s/merge [form] (parse-merge form))
 

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -314,4 +314,7 @@
       "Coerce new vals appropriately")
   (is (= {:foo 1 :bar "1" :c {:a 2}}
          (sc/coerce ::merge {:foo 1 :bar "1" :c {:a 2}}))
-      "Leave out ok vals"))
+      "Leave out ok vals")
+
+  (is (= "garbage" (sc/coerce ::merge "garbage"))
+      "garbage is passthrough"))

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -303,3 +303,15 @@
 (deftest test-or-conditions-in-unqualified-keys
   (is (= (sc/coerce ::unqualified {:foo "1" :bar "hi"})
          {:foo 1 :bar "hi"})))
+
+(deftest test-merge
+  (s/def ::merge (s/merge (s/keys :req-un [::foo])
+                          ::unqualified
+                          ;; TODO: add s/multi-spec test
+                          ))
+  (is (= {:foo 1 :bar "1" :c {:a 2}}
+         (sc/coerce ::merge {:foo "1" :bar 1 :c {:a 2}}))
+      "Coerce new vals appropriately")
+  (is (= {:foo 1 :bar "1" :c {:a 2}}
+         (sc/coerce ::merge {:foo 1 :bar "1" :c {:a 2}}))
+      "Leave out ok vals"))


### PR DESCRIPTION
add parse-merge and associated sym->coercer

parse-merge will reduce over every pred-form from s/merge and only
assoc values that changed (essentially the one that triggered
coercion) to the original map. 

It's certainly not the most efficient way to do this, but it's *correct* and simple in implementation. 

A more efficient implementation could/would try to resolve the s/keys from *pred-forms* first, merge them and do a single pass over the keys, but I am not sure about corner cases involved with keyword based *pred-forms* or eventual multi-specs, since we would have to resolve them down to the actual `s/keys` form involved.

ref #32

would need to be updated (add a test) if #31 is merged first.

