### PR TITLE
Remove "nil" "null" -> nil coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# spec-coerce [![Clojars Project](https://img.shields.io/clojars/v/spec-coerce.svg)](https://clojars.org/spec-coerce) ![Test](https://github.com/wilkerlucio/spec-coerce/workflows/Test/badge.svg?branch=master) [![cljdoc badge](https://cljdoc.xyz/badge/spec-coerce/spec-coerce)](https://cljdoc.xyz/d/spec-coerce/spec-coerce/CURRENT) 
+# spec-coerce [![Clojars Project](https://img.shields.io/clojars/v/spec-coerce.svg)](https://clojars.org/spec-coerce) ![Test](https://github.com/wilkerlucio/spec-coerce/workflows/Test/badge.svg?branch=master) [![cljdoc badge](https://cljdoc.xyz/badge/spec-coerce/spec-coerce)](https://cljdoc.xyz/d/spec-coerce/spec-coerce/CURRENT)
 
 A Clojure(script) library designed to leverage your specs to coerce your information into correct types.
 
@@ -13,7 +13,7 @@ Learn by example:
   (:require
     [clojure.spec.alpha :as s]
     [spec-coerce.core :as sc]))
-    
+
 ; Define a spec as usual
 (s/def ::number int?)
 
@@ -42,8 +42,8 @@ Learn by example:
 (sc/coerce `int? "40") ; => 40
 
 ; Parsers are written to be safe to call, when unable to coerce they will return the original value
-(sc/coerce `int? "40.2") ; => "40.2" 
-(sc/coerce `inst? "date") ; => "date" 
+(sc/coerce `int? "40.2") ; => "40.2"
+(sc/coerce `inst? "date") ; => "date"
 
 ; To leverage map keys and coerce a composed structure, use coerce-structure
 (sc/coerce-structure {::number      "42"
@@ -137,8 +137,7 @@ Examples from predicate to coerced value:
 ; Others
 (sc/coerce `uuid? "d6e73cc5-95bc-496a-951c-87f11af0d839")   ; => #uuid "d6e73cc5-95bc-496a-951c-87f11af0d839"
 (sc/coerce `inst? "2017-07-21")                             ; => #inst "2017-07-21T00:00:00.000000000-00:00"
-(sc/coerce `nil? "nil")                                     ; => nil
-(sc/coerce `nil? "null")                                    ; => nil
+(sc/coerce `nil? nil)                                       ; => nil
 
 ;; Clojure only:
 (sc/coerce `uri? "http://site.com") ; => (URI. "http://site.com")

--- a/src/spec_coerce/core.cljc
+++ b/src/spec_coerce/core.cljc
@@ -151,14 +151,6 @@
        (symbol x))
      x)))
 
-(defn parse-nil
-  ([x] (parse-nil x nil))
-  ([x _]
-   (if (and (string? x)
-            (#{"nil" "null"} (str/trim x)))
-     nil
-     x)))
-
 (defn parse-or [[_ & pairs]]
   (fn [x opts]
     (reduce (fn [x [_ pred]]
@@ -285,7 +277,6 @@
 (defmethod sym->coercer `qualified-symbol? [_] parse-symbol)
 (defmethod sym->coercer `uuid? [_] parse-uuid)
 (defmethod sym->coercer `inst? [_] parse-inst)
-(defmethod sym->coercer `nil? [_] parse-nil)
 (defmethod sym->coercer `false? [_] parse-boolean)
 (defmethod sym->coercer `true? [_] parse-boolean)
 (defmethod sym->coercer `zero? [_] parse-long)
@@ -354,9 +345,7 @@
 (defn gen-nilable-coercer
   [coercer]
   (fn [x opts]
-    (some-> x
-            (parse-nil opts)
-            (coercer opts))))
+    (some-> x (coercer opts))))
 
 (defn spec->coercion [root-spec]
   (-> root-spec

--- a/test/spec_coerce/core_test.cljc
+++ b/test/spec_coerce/core_test.cljc
@@ -78,7 +78,7 @@
 
   (testing "go over nilables"
     (is (= (sc/coerce ::infer-nilable "123") 123))
-    (is (= (sc/coerce ::infer-nilable "nil") nil))
+    (is (= (sc/coerce ::infer-nilable nil) nil))
     (is (= (sc/coerce ::nilable-int "10") 10))
     (is (= (sc/coerce ::nilable-pos-int "10") 10))
 
@@ -95,7 +95,7 @@
     (is (= (sc/coerce ::string-set "hey") "hey"))
     (is (= (sc/coerce ::keyword-set ":b") :b))
     (is (= (sc/coerce ::uuid-set "d6e73cc5-95bc-496a-951c-87f11af0d839") #uuid "d6e73cc5-95bc-496a-951c-87f11af0d839"))
-    (is (= (sc/coerce ::nil-set "nil") nil))
+    (is (= (sc/coerce ::nil-set nil) nil))
     ;;#?(:clj (is (= (sc/coerce ::uri-set "http://site.com") (URI. "http://site.com"))))
     #?(:clj (is (= (sc/coerce ::decimal-set "42.42M") 42.42M)))
 
@@ -153,8 +153,7 @@
     `simple-symbol? "simple-sym" 'simple-sym
     `qualified-symbol? "qualified/sym" 'qualified/sym
     `uuid? "d6e73cc5-95bc-496a-951c-87f11af0d839" #uuid "d6e73cc5-95bc-496a-951c-87f11af0d839"
-    `nil? "nil" nil
-    `nil? "null" nil
+    `nil? nil nil
     `false? "false" false
     `true? "true" true
     `zero? "0" 0


### PR DESCRIPTION
This is the wrong thing to do in my opinion.

A string field with `"nil"` or `"null"` or `"nil    "` as text are a perfectly valid strings and should not  be auto-coerced to `nil`. A typical example would be a db field with description="nil" that gets converted to `nil` with (nilable string?) as spec. 

I personally cannot think of a good reason to do this coercion and I am afraid this could cause issues.

That PR removes that auto-coercion and makes no assumption on how to coerce anything to nil (nil = nil only in essence)